### PR TITLE
fixed : removed constexpr keywords

### DIFF
--- a/TextBreaker/Src/GameContext/GameContextData.cpp
+++ b/TextBreaker/Src/GameContext/GameContextData.cpp
@@ -16,11 +16,11 @@ const std::string& TextGameEngine::GameContext::GameContextData::GetNowSceneName
     return _nowSceneName;
 }
 
-constexpr double TextGameEngine::GameContext::GameContextData::GetFrameTimeInterval() const
+double TextGameEngine::GameContext::GameContextData::GetFrameTimeInterval() const
 {
     return _frameTimeInterval;
 }
-constexpr double TextGameEngine::GameContext::GameContextData::GetFixedTimeInterval() const
+double TextGameEngine::GameContext::GameContextData::GetFixedTimeInterval() const
 {
     return _fixedTimeInterval;
 }


### PR DESCRIPTION
컴파일 오류를 일으키는 제거되지 않은 constexpr키워드를 GameContextData.cpp에서 제거했습니다